### PR TITLE
Change of network interface

### DIFF
--- a/hosts/dhis2-validation.nix
+++ b/hosts/dhis2-validation.nix
@@ -27,7 +27,7 @@
 
   networking = {
     hostName = "dhis2-validation";
-    interfaces.ens32 = {
+    interfaces.ens160 = {
       useDHCP = false;
       ipv4.addresses = [ { address = "192.168.50.54"; prefixLength = 24; } ];
     };


### PR DESCRIPTION
Following https://msfocbhelp.zendesk.com/agent/tickets/47907, we changed network interface from ens32 to ens160.

IP settings remain unchanged.

Once applied to the server, we'll remove ens32 interface.