### PR TITLE
Export the MSFOCB_SECRETS_DIRECTORY variable for all shells.

### DIFF
--- a/modules/system.nix
+++ b/modules/system.nix
@@ -122,6 +122,7 @@ with lib;
       };
       variables = {
         EDITOR = "vim";
+        MSFOCB_SECRETS_DIRECTORY=cfg.secretsDirectory;
       };
     };
 

--- a/msf_lib.nix
+++ b/msf_lib.nix
@@ -197,7 +197,8 @@ with lib;
                                 branch = git_branch; }}
 
         # Include the following additional variables in the environment
-        export MSFOCB_SECRETS_DIRECTORY="${secretsDirectory}" \
+        # MSFOCB_SECRETS_DIRECTORY is defined in modules/system.nix
+        export MSFOCB_SECRETS_DIRECTORY \
                MSFOCB_DEPLOY_DIR="${deploy_dir}"
 
         # Login to our private docker repo (hosted on github)


### PR DESCRIPTION
We rely on this variable in our docker-compose files and if it is not
defined in the shell, docker-compose can show errors even on subcommands
that do not need the variable to be present, leading to confusion.