### PR TITLE
Include Nomad, missing config: cluster discovery, TLS, ACL.

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -11,6 +11,7 @@
     ./maintenance.nix
     ./network.nix
     ./nfs.nix
+    ./nomad.nix
     ./packages.nix
     ./panic_button.nix
     ./prometheus.nix

--- a/modules/nomad.nix
+++ b/modules/nomad.nix
@@ -1,0 +1,39 @@
+{ config, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.settings.services.nomad;
+in
+
+{
+  # We backport Nomad 1.0 from the nixpkgs master repo
+  # until it becomes available in the 21.05 release.
+  imports = [ ./nomad/nomad.nix ];
+
+  options.settings.services.nomad = {
+    enable = mkEnableOption "the Nomad service";
+
+    datacenter = mkOption {
+      type = types.str;
+    };
+
+    cluster_size = mkOption {
+      type = types.int;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.nomad.backported = {
+      enable = cfg.enable;
+      settings = {
+        datacenter = cfg.datacenter;
+        server = {
+          enabled = true;
+          bootstrap_expect = cfg.cluster_size;
+        };
+      };
+    };
+  };
+}
+

--- a/modules/nomad/1.0.nix
+++ b/modules/nomad/1.0.nix
@@ -1,0 +1,12 @@
+{ callPackage
+, buildGoPackage
+, nvidia_x11
+, nvidiaGpuSupport
+}:
+
+callPackage ./generic.nix {
+  inherit buildGoPackage nvidia_x11 nvidiaGpuSupport;
+  version = "1.0.4";
+  sha256 = "0znaxz9mzbqb59p6rwa5h89m344m2ci39jsx8dfh1v5fc17r0fcq";
+}
+

--- a/modules/nomad/generic.nix
+++ b/modules/nomad/generic.nix
@@ -1,0 +1,59 @@
+{ lib
+, buildGoPackage
+, fetchFromGitHub
+, version
+, sha256
+, nvidiaGpuSupport
+, patchelf
+, nvidia_x11
+}:
+
+buildGoPackage rec {
+  pname = "nomad";
+  inherit version;
+  rev = "v${version}";
+
+  goPackagePath = "github.com/hashicorp/nomad";
+  subPackages = [ "." ];
+
+  src = fetchFromGitHub {
+    owner = "hashicorp";
+    repo = pname;
+    inherit rev sha256;
+  };
+
+  nativeBuildInputs = lib.optionals nvidiaGpuSupport [
+    patchelf
+  ];
+
+  # ui:
+  #  Nomad release commits include the compiled version of the UI, but the file
+  #  is only included if we build with the ui tag.
+  preBuild =
+    let
+      tags = [ "ui" ] ++ lib.optional (!nvidiaGpuSupport) "nonvidia";
+      tagsString = lib.concatStringsSep " " tags;
+    in
+    ''
+      export buildFlagsArray=(
+        -tags="${tagsString}"
+      )
+    '';
+
+  # The dependency on NVML isn't explicit. We have to make it so otherwise the
+  # binary will not know where to look for the relevant symbols.
+  postFixup = lib.optionalString nvidiaGpuSupport ''
+    for bin in $out/bin/*; do
+      patchelf --add-needed "${nvidia_x11}/lib/libnvidia-ml.so" "$bin"
+    done
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.nomadproject.io/";
+    description = "A Distributed, Highly Available, Datacenter-Aware Scheduler";
+    platforms = platforms.unix;
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ rushmorem pradeepchhetri endocrimes ];
+  };
+}
+

--- a/modules/nomad/nomad.nix
+++ b/modules/nomad/nomad.nix
@@ -1,0 +1,172 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let
+  cfg = config.services.nomad.backported;
+  format = pkgs.formats.json { };
+in
+{
+  ##### interface
+  options = {
+    services.nomad.backported = {
+      enable = mkEnableOption "Nomad, a distributed, highly available, datacenter-aware scheduler";
+
+      package = mkOption {
+        type = types.package;
+        default = let
+          nomad_1_0 = pkgs.callPackage ./1.0.nix {
+            buildGoPackage = pkgs.buildGo115Package;
+            inherit (pkgs.linuxPackages) nvidia_x11;
+            nvidiaGpuSupport = config.cudaSupport or false;
+          };
+        in nomad_1_0;
+        defaultText = "pkgs.nomad";
+        description = ''
+          The package used for the Nomad agent and CLI.
+        '';
+      };
+
+      extraPackages = mkOption {
+        type = types.listOf types.package;
+        default = [ ];
+        description = ''
+          Extra packages to add to <envar>PATH</envar> for the Nomad agent process.
+        '';
+        example = literalExample ''
+          with pkgs; [ cni-plugins ]
+        '';
+      };
+
+      dropPrivileges = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether the nomad agent should be run as a non-root nomad user.
+        '';
+      };
+
+      enableDocker = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Enable Docker support. Needed for Nomad's docker driver.
+
+          Note that the docker group membership is effectively equivalent
+          to being root, see https://github.com/moby/moby/issues/9976.
+        '';
+      };
+
+      extraSettingsPaths = mkOption {
+        type = types.listOf types.path;
+        default = [];
+        description = ''
+          Additional settings paths used to configure nomad. These can be files or directories.
+        '';
+        example = literalExample ''
+          [ "/etc/nomad-mutable.json" "/run/keys/nomad-with-secrets.json" "/etc/nomad/config.d" ]
+        '';
+      };
+
+      settings = mkOption {
+        type = format.type;
+        default = {};
+        description = ''
+          Configuration for Nomad. See the <link xlink:href="https://www.nomadproject.io/docs/configuration">documentation</link>
+          for supported values.
+
+          Notes about <literal>data_dir</literal>:
+
+          If <literal>data_dir</literal> is set to a value other than the
+          default value of <literal>"/var/lib/nomad"</literal> it is the Nomad
+          cluster manager's responsibility to make sure that this directory
+          exists and has the appropriate permissions.
+
+          Additionally, if <literal>dropPrivileges</literal> is
+          <literal>true</literal> then <literal>data_dir</literal>
+          <emphasis>cannot</emphasis> be customized. Setting
+          <literal>dropPrivileges</literal> to <literal>true</literal> enables
+          the <literal>DynamicUser</literal> feature of systemd which directly
+          manages and operates on <literal>StateDirectory</literal>.
+        '';
+        example = literalExample ''
+          {
+            # A minimal config example:
+            server = {
+              enabled = true;
+              bootstrap_expect = 1; # for demo; no fault tolerance
+            };
+            client = {
+              enabled = true;
+            };
+          }
+        '';
+      };
+    };
+  };
+
+  ##### implementation
+  config = mkIf cfg.enable {
+    services.nomad.backported.settings = {
+      # Agrees with `StateDirectory = "nomad"` set below.
+      data_dir = mkDefault "/var/lib/nomad";
+    };
+
+    environment = {
+      etc."nomad.json".source = format.generate "nomad.json" cfg.settings;
+      systemPackages = [ cfg.package ];
+    };
+
+    systemd.services.nomad = {
+      description = "Nomad";
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
+      restartTriggers = [ config.environment.etc."nomad.json".source ];
+
+      path = cfg.extraPackages ++ (with pkgs; [
+        # Client mode requires at least the following:
+        coreutils
+        iproute
+        iptables
+      ]);
+
+      serviceConfig = mkMerge [
+        {
+          DynamicUser = cfg.dropPrivileges;
+          ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+          ExecStart = "${cfg.package}/bin/nomad agent -config=/etc/nomad.json" +
+            concatMapStrings (path: " -config=${path}") cfg.extraSettingsPaths;
+          KillMode = "process";
+          KillSignal = "SIGINT";
+          LimitNOFILE = 65536;
+          LimitNPROC = "infinity";
+          OOMScoreAdjust = -1000;
+          Restart = "on-failure";
+          RestartSec = 2;
+          TasksMax = "infinity";
+        }
+        (mkIf cfg.enableDocker {
+          SupplementaryGroups = "docker"; # space-separated string
+        })
+        (mkIf (cfg.settings.data_dir == "/var/lib/nomad") {
+          StateDirectory = "nomad";
+        })
+      ];
+
+      unitConfig = {
+        StartLimitIntervalSec = 10;
+        StartLimitBurst = 3;
+      };
+    };
+
+    assertions = [
+      {
+        assertion = cfg.dropPrivileges -> cfg.settings.data_dir == "/var/lib/nomad";
+        message = "settings.data_dir must be equal to \"/var/lib/nomad\" if dropPrivileges is true";
+      }
+    ];
+
+    # Docker support requires the Docker daemon to be running.
+    virtualisation.docker.enable = mkIf cfg.enableDocker true;
+  };
+}
+


### PR DESCRIPTION
We included a backported version of Nomad, from NixOS 21.05 onwards, we can just use the upstream versions.