### PR TITLE
No longer specify an alternate certificate chain.

### DIFF
--- a/modules/traefik.nix
+++ b/modules/traefik.nix
@@ -170,8 +170,6 @@ in
       docker.enable = true;
 
       services.traefik = {
-        acme.crossSignedChain.enable = true;
-
         dynamic_config.default_config = {
           enable = true;
           value = {


### PR DESCRIPTION
LE are changing their default chain to one that maintains compatibility
with older Android devices.
https://community.letsencrypt.org/t/providing-a-longer-certificate-chain-by-default/148738