### PR TITLE
Remove temporary rename imports.

### DIFF
--- a/modules/system.nix
+++ b/modules/system.nix
@@ -126,11 +126,6 @@ with lib;
     };
   };
 
-  imports = [
-    (mkRenamedOptionModule [ "settings" "system" "secretsDirectory" ] [ "settings" "system" "secrets" "dest_directory" ])
-    (mkRenamedOptionModule [ "settings" "system" "secrets_src_directory" ] [ "settings" "system" "secrets" "src_directory" ])
-  ];
-
   config = {
 
     assertions = [


### PR DESCRIPTION
These were only required to be able to commit dependent changes to our two NixOS repos without causing the checks to fail.