### PR TITLE
Installer automatically commit encryption keys

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -224,7 +224,7 @@ if [ "${CREATE_DATA_PART}" = true ]; then
 
   function decrypt_secrets() {
     mkdir --parents "${secrets_dir}"
-    nix-shell "${nixos_dir}"/scripts/ocb_nixos_python_scripts/shell.nix \
+    nix-shell "${nixos_dir}"/scripts/python_nixostools/shell.nix \
               --run "decrypt_server_secrets \
                        --server_name ${TARGET_HOSTNAME} \
                        --secrets_path ${config_dir}/secrets/generated \
@@ -235,7 +235,7 @@ if [ "${CREATE_DATA_PART}" = true ]; then
   decrypt_secrets
   keyfile="${secrets_dir}/keyfile"
   if [ ! -f "${keyfile}" ]; then
-    nix-shell "${nixos_dir}"/scripts/ocb_nixos_python_scripts/shell.nix \
+    nix-shell "${nixos_dir}"/scripts/python_nixostools/shell.nix \
               --run "add_encryption_key \
                        --hostname ${TARGET_HOSTNAME} \
                        --secrets_file ${config_dir}/secrets/nixos_encryption-secrets.yml"

--- a/install.sh
+++ b/install.sh
@@ -204,7 +204,7 @@ nix-shell --packages git --run "git config --global core.sshCommand 'ssh -i /tmp
 if [ "${CREATE_DATA_PART}" = true ]; then
   nixos_dir="/tmp/nixos/"
   config_dir="${nixos_dir}/org-config/"
-  secrets_dir="/run/.secrets/"
+  secrets_dir="${MSFOCB_SECRETS_DIRECTORY}"
 
   # Clean up potential left-over directories
   if [ -e "${nixos_dir}" ]; then
@@ -379,10 +379,10 @@ if [ "${CREATE_DATA_PART}" = true ]; then
              --use-urandom \
              luksFormat \
              --type luks2 \
-             --key-file /run/.secrets/keyfile \
+             --key-file "${MSFOCB_SECRETS_DIRECTORY}/keyfile" \
              /dev/LVMVolGroup/nixos_data
   cryptsetup open \
-             --key-file /run/.secrets/keyfile \
+             --key-file "${MSFOCB_SECRETS_DIRECTORY}/keyfile" \
              /dev/LVMVolGroup/nixos_data nixos_data_decrypted
   mkfs.ext4 -e remount-ro \
             -m 1 \

--- a/install.sh
+++ b/install.sh
@@ -221,11 +221,12 @@ if [ "${CREATE_DATA_PART}" = true ]; then
 
   function decrypt_secrets() {
     mkdir --parents "${secrets_dir}"
-    "${nixos_dir}"/scripts/secrets/decrypt_server_secrets.py \
-      --server_name "${TARGET_HOSTNAME}" \
-      --secrets_path "${config_dir}/secrets/generated" \
-      --output_path "${secrets_dir}" \
-      --private_key_file "/tmp/id_tunnel" > /dev/null
+    nix-shell "${nixos_dir}"/scripts/ocb_nixos_python_scripts/shell.nix \
+              --run "decrypt_server_secrets \
+                       --server_name ${TARGET_HOSTNAME} \
+                       --secrets_path ${config_dir}/secrets/generated \
+                       --output_path ${secrets_dir} \
+                       --private_key_file /tmp/id_tunnel > /dev/null"
   }
 
   decrypt_secrets

--- a/install.sh
+++ b/install.sh
@@ -219,7 +219,7 @@ if [ "${CREATE_DATA_PART}" = true ]; then
   nix-shell --packages git --run "git clone ${config_repo} \
                                       ${config_dir}"
 
-  function generate_secrets() {
+  function decrypt_secrets() {
     mkdir --parents "${secrets_dir}"
     "${nixos_dir}"/scripts/secrets/decrypt_server_secrets.py \
       --server_name "${TARGET_HOSTNAME}" \
@@ -228,7 +228,7 @@ if [ "${CREATE_DATA_PART}" = true ]; then
       --private_key_file "/tmp/id_tunnel" > /dev/null
   }
 
-  generate_secrets
+  decrypt_secrets
   keyfile="${secrets_dir}/keyfile"
   if [ ! -f "${keyfile}" ]; then
     "${nixos_dir}"/scripts/secrets/add_encryption_key.py \
@@ -258,7 +258,7 @@ if [ "${CREATE_DATA_PART}" = true ]; then
     while [ ! -f "${keyfile}" ]; do
       nix-shell --packages git --run "git -C ${config_dir} \
                                           pull > /dev/null 2>&1"
-      generate_secrets
+      decrypt_secrets
       if [ ! -f "${keyfile}" ]; then
         sleep 10
       fi

--- a/install.sh
+++ b/install.sh
@@ -155,6 +155,9 @@ if [ ! -f "/tmp/id_tunnel" ] || [ ! -f "/tmp/id_tunnel.pub" ]; then
              -C "" \
              -f /tmp/id_tunnel
   echo "SSH keypair generated."
+else
+  # Make sure that we have the right permissions
+  chmod 0400 /tmp/id_tunnel
 fi
 
 # Check whether we can authenticate to GitHub using this server's key

--- a/install.sh
+++ b/install.sh
@@ -194,6 +194,65 @@ fi
   echo "Successfully authenticated to GitHub."
 )
 
+# Set some global Git settings
+nix-shell --packages git --run "git config --global pull.rebase true"
+nix-shell --packages git --run "git config --global user.name 'OCB NixOS Robot'"
+nix-shell --packages git --run "git config --global user.email 'nixos-ocb@users.noreply.github.com'"
+nix-shell --packages git --run "git config --global core.sshCommand 'ssh -i /tmp/id_tunnel'"
+
+# Commit a new encryption key to GitHub
+if [ "${CREATE_DATA_PART}" = true ]; then
+  if [ -e "/tmp/nixos" ]; then
+    rm --recursive --force "/tmp/nixos"
+  fi
+
+  nix-shell --packages git --run "git clone ${main_repo} \
+                                      /tmp/nixos"
+  nix-shell --packages git --run "git clone ${config_repo} \
+                                      /tmp/nixos/org-config"
+
+  /tmp/nixos/scripts/secrets/add_encryption_key.py \
+    --hostname "${TARGET_HOSTNAME}"\
+    --secrets_file "/tmp/nixos/org-config/secrets/nixos_encryption-secrets.yml"
+
+  random_id=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 10)
+  branch_name="installer_commit_enc_key_${TARGET_HOSTNAME}_${random_id}"
+  nix-shell --packages git --run "git -C /tmp/nixos/org-config \
+                                      checkout -b ${branch_name}"
+  nix-shell --packages git --run "git -C /tmp/nixos/org-config \
+                                      add secrets/nixos_encryption-secrets.yml"
+  nix-shell --packages git --run "git -C /tmp/nixos/org-config \
+                                      commit \
+                                      --message 'Commit encryption key for ${TARGET_HOSTNAME}.'"
+  nix-shell --packages git --run "git -C /tmp/nixos/org-config \
+                                      push -u origin ${branch_name}"
+
+  echo -e "\n\nThe encryption key for this server was committed to GitHub"
+  echo -e "Please go to the following link to create a pull request:"
+  echo -e "\nhttps://github.com/MSF-OCB/NixOS-OCB-config/pull/new/${branch_name}\n"
+  echo -e "The installer will continue once the pull request has been merged into master."
+
+  nix-shell --packages git --run "git -C /tmp/nixos/org-config \
+                                      checkout master"
+
+  secret_present=false
+  while [ "${secret_present}" = false ]; do
+    nix-shell --packages git --run "git -C /tmp/nixos/org-config \
+                                        pull > /dev/null 2>&1"
+    mkdir --parents /run/.secrets/
+    /tmp/nixos/scripts/secrets/decrypt_server_secrets.py \
+      --server_name "${TARGET_HOSTNAME}" \
+      --secrets_path "/tmp/nixos/org-config/secrets/generated" \
+      --output_path "/run/.secrets" \
+      --private_key_file "/tmp/id_tunnel" > /dev/null
+    if [ -f "/run/.secrets/keyfile" ]; then
+      secret_present=true
+    else
+      sleep 10
+    fi
+  done
+fi
+
 detect_swap="$(swapon | grep "${swapfile}" > /dev/null 2>&1; echo $?)"
 if [ "${detect_swap}" -eq "0" ]; then
   swapoff "${swapfile}"
@@ -285,67 +344,15 @@ mkswap "${swapfile}"
 swapon "${swapfile}"
 
 rm --recursive --force /mnt/etc/
-nix-shell --packages git --run "git -c core.sshCommand='ssh -i /tmp/id_tunnel' \
-                                    clone ${main_repo} \
+nix-shell --packages git --run "git clone ${main_repo} \
                                     /mnt/etc/nixos/"
-nix-shell --packages git --run "git -c core.sshCommand='ssh -i /tmp/id_tunnel' \
-                                    clone ${config_repo} \
+nix-shell --packages git --run "git clone ${config_repo} \
                                     /mnt/etc/nixos/org-config"
 nixos-generate-config --root /mnt --no-filesystems
 ln --symbolic org-config/hosts/"${TARGET_HOSTNAME}".nix /mnt/etc/nixos/settings.nix
 cp /tmp/id_tunnel /tmp/id_tunnel.pub /mnt/etc/nixos/local/
 
 if [ "${CREATE_DATA_PART}" = true ]; then
-  if [ -e "/tmp/nixos-ocb-config" ]; then
-    rm --recursive --force "/tmp/nixos-ocb-config"
-  fi
-  nix-shell --packages git --run "git config --global pull.rebase true"
-  nix-shell --packages git --run "git -c core.sshCommand='ssh -i /tmp/id_tunnel' \
-                                      clone ${config_repo} \
-                                      /tmp/nixos-ocb-config"
-
-  /mnt/etc/nixos/scripts/secrets/add_encryption_key.py \
-    --hostname "${TARGET_HOSTNAME}"\
-    --secrets_file "/tmp/nixos-ocb-config/secrets/nixos_encryption-secrets.yml"
-
-  random_id=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 10)
-  branch_name="installer_commit_enc_key_${TARGET_HOSTNAME}_${random_id}"
-  nix-shell --packages git --run "git -C /tmp/nixos-ocb-config \
-                                      checkout -b ${branch_name}"
-  nix-shell --packages git --run "git -C /tmp/nixos-ocb-config \
-                                      add secrets/nixos_encryption-secrets.yml"
-  nix-shell --packages git --run "git -C /tmp/nixos-ocb-config \
-                                      -c user.name='OCB NixOS Robot' \
-                                      -c user.email='nixos-ocb@users.noreply.github.com' \
-                                      commit \
-                                      --message 'Commit encryption key for ${TARGET_HOSTNAME}.'"
-  nix-shell --packages git --run "git -C /tmp/nixos-ocb-config \
-                                      -c core.sshCommand='ssh -i /tmp/id_tunnel' \
-                                      push -u origin ${branch_name}"
-
-  echo -e "\n\nThe encryption key for this server was committed to GitHub"
-  echo -e "Please go to the following link to create a pull request:"
-  echo -e "\nhttps://github.com/MSF-OCB/NixOS-OCB-config/pull/new/${branch_name}\n"
-  echo -e "The installer will continue once the pull request has been merged into master."
-
-  secret_present=false
-  while [ "${secret_present}" = false ]; do
-    nix-shell --packages git --run "git -C /mnt/etc/nixos/org-config \
-                                        -c core.sshCommand='ssh -i /tmp/id_tunnel' \
-                                        pull > /dev/null 2>&1"
-    mkdir --parents /run/.secrets/
-    /mnt/etc/nixos/scripts/secrets/decrypt_server_secrets.py \
-      --server_name "${TARGET_HOSTNAME}" \
-      --secrets_path "/mnt/etc/nixos/org-config/secrets/generated" \
-      --output_path "/run/.secrets" \
-      --private_key_file "/tmp/id_tunnel" > /dev/null
-    if [ -f "/run/.secrets/keyfile" ]; then
-      secret_present=true
-    else
-      sleep 10
-    fi
-  done
-
   # Do this only after having generated the hardware config
   lvcreate --yes --extents 100%FREE --name nixos_data LVMVolGroup
   wait_for_devices "/dev/LVMVolGroup/nixos_data"

--- a/install.sh
+++ b/install.sh
@@ -232,9 +232,10 @@ if [ "${CREATE_DATA_PART}" = true ]; then
   decrypt_secrets
   keyfile="${secrets_dir}/keyfile"
   if [ ! -f "${keyfile}" ]; then
-    "${nixos_dir}"/scripts/secrets/add_encryption_key.py \
-      --hostname "${TARGET_HOSTNAME}"\
-      --secrets_file "${config_dir}/secrets/nixos_encryption-secrets.yml"
+    nix-shell "${nixos_dir}"/scripts/ocb_nixos_python_scripts/shell.nix \
+              --run "add_encryption_key \
+                       --hostname ${TARGET_HOSTNAME} \
+                       --secrets_file ${config_dir}/secrets/nixos_encryption-secrets.yml"
 
     random_id=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 10)
     branch_name="installer_commit_enc_key_${TARGET_HOSTNAME}_${random_id}"

--- a/scripts/python_nixostools/nixostools/add_encryption_key.py
+++ b/scripts/python_nixostools/nixostools/add_encryption_key.py
@@ -1,0 +1,54 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i python3 ../shell.nix
+
+import argparse
+import secrets
+
+from nixostools import ansible_vault_lib
+
+from nixostools.secret_lib import SECRETS_KEY, \
+                                  SERVERS_KEY, \
+                                  PATH_KEY, \
+                                  CONTENT_KEY
+
+
+def args_parser() -> argparse.ArgumentParser:
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--hostname", dest="hostname", required=True, type=str)
+  parser.add_argument("--secrets_file", dest="secrets_file", required=True, type=str,
+                      help="path to the file where we should store the generated encryption keys")
+  parser.add_argument("--ansible_vault_passwd", dest="ansible_vault_passwd", required=False, type=str,
+                      help="the ansible-vault password, if empty the script will ask for the password")
+  return parser
+
+
+def print_vault_banner() -> None:
+  print("\n\nYou will need the key for the Ansible Vault storing the encryption keys.")
+  print("This key can be found here:")
+  print("\nhttps://start.1password.com/open/i?a=3ZSXL3IG55ER5E467CLRTXXE4U&h=msfocb.1password.eu&i=3zol6ujo4xg7vcxp5sxxt5mjpa&v=xsnpr3xpsu3x433llrascuqj4e\n")
+
+
+def main() -> None:
+  args = args_parser().parse_args()
+
+  print_vault_banner()
+  ansible_vault_passwd = ansible_vault_lib.get_ansible_passwd(args.ansible_vault_passwd)
+
+  data = ansible_vault_lib.read_vault_file(ansible_vault_passwd,
+                                           args.secrets_file) \
+         or { SECRETS_KEY: {} }
+
+  data[SECRETS_KEY][f'{args.hostname}-encryption-key'] = {
+    PATH_KEY: "keyfile",
+    CONTENT_KEY: secrets.token_hex(64),
+    SERVERS_KEY: [ args.hostname ]
+  }
+
+  ansible_vault_lib.write_vault_file(ansible_vault_passwd,
+                                     args.secrets_file,
+                                     data)
+
+
+if __name__ == "__main__":
+  main()
+

--- a/scripts/python_nixostools/nixostools/add_encryption_key.py
+++ b/scripts/python_nixostools/nixostools/add_encryption_key.py
@@ -34,9 +34,11 @@ def main() -> None:
   print_vault_banner()
   ansible_vault_passwd = ansible_vault_lib.get_ansible_passwd(args.ansible_vault_passwd)
 
-  data = ansible_vault_lib.read_vault_file(ansible_vault_passwd,
-                                           args.secrets_file) \
-         or { SECRETS_KEY: {} }
+  try:
+    data = ansible_vault_lib.read_vault_file(ansible_vault_passwd,
+                                             args.secrets_file)
+  except FileNotFoundError:
+    data = { SECRETS_KEY: {} }
 
   data[SECRETS_KEY][f'{args.hostname}-encryption-key'] = {
     PATH_KEY: "keyfile",

--- a/scripts/python_nixostools/setup.py
+++ b/scripts/python_nixostools/setup.py
@@ -7,6 +7,7 @@ setup (
     "console_scripts": [
       "encrypt_server_secrets = nixostools.encrypt_server_secrets:main",
       "decrypt_server_secrets = nixostools.decrypt_server_secrets:main",
+      "add_encryption_key     = nixostools.add_encryption_key:main",
     ]
   },
 )


### PR DESCRIPTION
# Problem statement

Most of our servers have an encrypted partition mounted on `/opt`.
The encryption is done using the standard `dmcrypt` subsystem and the LUKS standard for key management.

The encryption key for the `/opt` partition is currently stored in clear text on our root partition in the file `/keyfile`.
This key is not backed up, and currently we require a second passphrase to be manually added to the LUKS header and to 1PW to deal with lost key files.

This manual intervention is error prone, time consuming, can easily be forgotten, and cannot easily be verified remotely.

The goal of this change is to:
1. Eliminate the manual step of creating a passphrase, setting it on the server, and saving it in 1PW
2. Have the key file stored in an encrypted format on the remote servers, protected by the server's private key (like all other secrets)
3. Have the key files stored centrally in our git repository, protected by our usual secret management system
4. Provide an easy migration path, ideally without the need to carry out manual operations on every server one-by-one

# Proposed solution

## Keys generated at install time and committed to GitHub

At install time, the install script will make a clone of our config repo.
The install script will then generate a new encryption key (see [`scripts/secrets/add_encryption_key.py`][add_key_script]) and add it to the encrypted secrets file `nixos_encryption-secrets.yml` in the [`secrets` dir][secrets_dir] of that config repo.
The script will ask for the Ansible Vault passphrase interactively in order to be able to modify this file.

It is important that this Ansible Vault passphrase never be stored on any remote server or in the installer ISO, as this would totally compromise the security of our secrets management system. 

The script will then create a new branch (using the name of the server being installed and a random string), create a commit with the new encryption key, and push it to GitHub.
In order to be able to push, the NixOS OCB Robot has been given write access to our config repo (but commits need to pass through PRs and be approved by someone else with commit rights before they can be merged into `master`).
The script will then ask the user to create a PR by pasting to the console a direct link to the page to create a PR for the newly created branch, and the script will keep on looping until the PR has been created, validated, and merged into master.

To check whether the PR has been merged, the install script will update its local clone and run the decryption script (see [`scripts/secrets/decrypt_server_secrets.py`][decrypt_script]) until it creates the expected `/run/.secrets/keyfile`, containing the key to be used for this server.
Once this secret is indeed present, the script can continue as it did before and use the key file where needed.

## Migrating existing setups

To migrate existing setups, a new encryption key will need to be generated for every server to be migrated and added to GitHub. This can be done easily by using the same [`scripts/secrets/add_encryption_key.py`][add_key_script] script used by the installer.
This script can be executed from any machine, it does not need to be run on the affected server, and so this can be done once in bulk for all existing servers.

Once a new encryption key has been added for an existing server, we will do the following once the server reboots and tries to mount its encrypted partition:
1. Check if a new encryption key at the new location exists
   1. If not, continue with the old key as before and do nothing more
2. If so, use the old encryption key to add the new one
3. Test if the new encryption key was successfully added and use it to open the encrypted volume
4. If all was successful, revoke the old key, which from that point onwards will be useless

This procedure allows us to easily define new keys for all existing servers, and the servers will independently migrate to the new keys, revoking the old ones in the process.
This procedure does not require any manual intervention on the remote servers and can be done once in bulk.

[add_key_script]: https://github.com/MSF-OCB/NixOS/tree/rvdp__installer_commit_enc_keys/scripts/secrets/add_encryption_key.py
[decrypt_script]: https://github.com/MSF-OCB/NixOS/blob/rvdp__installer_commit_enc_keys/scripts/secrets/decrypt_server_secrets.py
[secrets_dir]: https://github.com/MSF-OCB/NixOS-OCB-config/tree/master/secrets