### PR TITLE
Make sure Traefik gets triggered if Docker recovers after a failure.

### DIFF
--- a/modules/traefik.nix
+++ b/modules/traefik.nix
@@ -409,7 +409,11 @@ in
       "${traefik_docker_service_name}" = let
         dns_credentials_file = system_cfg.secrets.dest_directory + cfg.acme.dns_provider;
       in {
+        # Requires needs to be accompanied by an After condition in order to be effective
+        # See https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Requires=
         requires = [ "docker.service" ];
+        after    = [ "docker.service" ];
+        wantedBy = [ "docker.service" ];
         serviceConfig = {
           # Restore the defaults to have proper logging in the systemd journal.
           # See GitHub NixOS/nixpkgs issue #102768 and PR #102769


### PR DESCRIPTION
If Docker fails to start, Traefik will fail too, since we list Docker as a dependency. A unit failing like this with status "dependency", does not trigger its own restarting mechanism (it is deemed unrecoverable?).
With this change, we explicitly retrigger Traefik whenever Docker is started (the `WantedBy` directive), such that if Docker recovers after a failure, Traefik will get triggered too.