### PR TITLE
Refactor the reverse tunnels module.

### DIFF
--- a/modules/load_json.nix
+++ b/modules/load_json.nix
@@ -61,9 +61,21 @@ with (import ../msf_lib.nix);
                          enabledUsersByRoles);
 
       reverse_tunnel.tunnels = let
+        # We add the SSH tunnel by default
+        addSshTunnel  = tunnel: let
+          ssh_tunnel = {
+            reverse_tunnels = {
+              ssh = {
+                prefix = 0;
+                forwarded_port = 22;
+              };
+            };
+          };
+        in recursiveUpdate tunnel ssh_tunnel;
+        addSshTunnels = mapAttrs (_: addSshTunnel);
         tunnel_json_path = sys_cfg.tunnels_json_path;
         json_data        = importJSON tunnel_json_path;
-      in json_data.tunnels.per-host;
+      in addSshTunnels json_data.tunnels.per-host;
     };
   };
 }

--- a/modules/reverse-tunnel.nix
+++ b/modules/reverse-tunnel.nix
@@ -7,6 +7,30 @@ let
   cfg     = config.settings.reverse_tunnel;
   sys_cfg = config.settings.system;
 
+  reverseTunnelOpts = { name, ... }: {
+    options = {
+      name = mkOption {
+        type = types.str;
+      };
+      prefix = mkOption {
+        type = types.ints.between 0 5;
+        description = ''
+          Numerical prefix to be added to the main port.
+        '';
+      };
+      forwarded_port = mkOption {
+        type = types.port;
+        description = ''
+          The local port from this server to forward.
+        '';
+      };
+    };
+
+    config = {
+      name = mkDefault name;
+    };
+  };
+
   tunnelOpts = { name, ... }: {
     options = {
       name = mkOption {
@@ -14,13 +38,19 @@ let
       };
 
       remote_forward_port = mkOption {
-        type = types.ints.between 0 9999;
+        type = with types; either (ints.between 0 0) (ints.between 2000 9999);
         description = "The port used for this server on the relay servers.";
       };
 
-      # We allow the empty string to allow bootstrapping an installation where the key has not yet been generated
+      # We allow the empty string to allow bootstrapping
+      # an installation where the key has not yet been generated
       public_key = mkOption {
         type = types.either msf_lib.empty_str_type msf_lib.pub_key_type;
+      };
+
+      reverse_tunnels = mkOption {
+        type    = with types; attrsOf (submodule reverseTunnelOpts);
+        default = {};
       };
     };
 
@@ -42,6 +72,11 @@ let
       public_key = mkOption {
         type = msf_lib.pub_key_type;
       };
+
+      ports = mkOption {
+        type    = with types; listOf port;
+        default = [ 22 80 443 ];
+      };
     };
 
     config = {
@@ -62,50 +97,107 @@ in {
         type    = with types; attrsOf (submodule relayServerOpts);
       };
 
-      prometheus_tunnel_port_prefix = mkOption {
-        type    = types.ints.between 0 5;
-        default = 3;
-      };
-
       relay = {
         enable = mkEnableOption "the relay server functionality";
-
-        ports = mkOption {
-          type    = with types; listOf port;
-          default = [ 22 80 443 ];
-        };
 
         tunneller.keyFiles = mkOption {
           type    = with types; listOf path;
           default = [ ];
-          description = ''
-            The list of key files which are allowed to access the tunneller user to create tunnels.
-          '';
+          description = "The list of key files which are allowed to access " +
+                        "the tunneller user to create tunnels.";
         };
       };
     };
   };
 
   config = let
+    stringNotEmpty = s: stringLength s != 0;
+    includeTunnel  = tunnel: stringNotEmpty tunnel.public_key &&
+                             tunnel.remote_forward_port > 0;
     add_port_prefix = prefix: base_port: 10000 * prefix + base_port;
-    prometheus_enabled = config.settings.services.prometheus.enable;
+    extract_prefix = reverse_tunnel: reverse_tunnel.prefix;
+    get_prefixes = mapAttrsToList (_: extract_prefix);
+
+    # Load the config of the host currently being built from the settings
+    current_host_tunnel = cfg.tunnels.${config.networking.hostName};
   in mkIf (cfg.enable || cfg.relay.enable) {
+
+    assertions = let
+      # Functions to detect duplicate prefixes in our tunnel config
+      filter_duplicate_prefixes = prefixes: length prefixes != length (unique prefixes);
+      toPrefixes = tunnel: get_prefixes (tunnel.reverse_tunnels);
+      pretty_print_prefixes = host: prefixes: let
+        int_sort = sort (a: b: a < b);
+        sorted_prefixes = concatMapStringsSep ", " toString (int_sort prefixes);
+      in "${host}: ${sorted_prefixes}";
+
+      mkDuplicatePrefixes = msf_lib.compose [
+        (mapAttrsToList pretty_print_prefixes)       # pretty-print the results
+        (filterAttrs (_: filter_duplicate_prefixes)) # get hosts with duplicate prefixes
+        (mapAttrs (_: toPrefixes))                   # map tunnels configs to the prefixes
+      ];
+      duplicate_prefixes = mkDuplicatePrefixes cfg.tunnels;
+
+      # Function to use with foldr,
+      # given a tunnel conf and a set mapping ports to booleans,
+      # it will add the port to the set with a value of:
+      #   - false if the port was not previously there, and
+      #   - true  if the port had been added already
+      # The result after folding, is a set mapping duplicate ports to true.
+      # Port 0 is ignored since it is a placeholder port.
+      update_duplicates_set = tunnel: set: let
+        port = toString (cfg.tunnels.${tunnel}.remote_forward_port);
+      in set // { ${port} = port != "0" && hasAttr port set; };
+
+      # Use the update_duplicates_set function to calculate
+      # a set marking duplicate ports, filter out the duplicates,
+      # and return the result as a list of port numbers.
+      mkDuplicatePorts = msf_lib.compose [
+        attrNames                        # return the name only (=port number)
+        (filterAttrs (flip const))       # filter on trueness of the value
+        (foldr update_duplicates_set {}) # fold to create the duplicates set
+        attrNames                        # convert to a list of tunnel names
+      ];
+      duplicate_ports = mkDuplicatePorts cfg.tunnels;
+    in [
+      {
+        assertion = length duplicate_prefixes == 0;
+        message   = "Duplicate prefixes defined! Details: " +
+                    concatStringsSep "; " duplicate_prefixes;
+      }
+      {
+        assertion = length duplicate_ports == 0;
+        message   = "Duplicate tunnel ports defined! " +
+                    "Duplicates: " +
+                    concatStringsSep ", " duplicate_ports;
+      }
+      {
+        assertion = cfg.relay.enable ->
+                    hasAttr config.networking.hostName cfg.relay_servers;
+        message   = "This host is set as a relay, " +
+                    "but its host name could not be found in the list of relays! " +
+                    "Defined relays: " +
+                    concatStringsSep ", "  (attrNames cfg.relay_servers);
+      }
+    ];
 
     users.extraUsers = {
       tunnel = let
-        stringNotEmpty = s: stringLength s != 0;
-        includeTunnel  = tunnel: stringNotEmpty tunnel.public_key && tunnel.remote_forward_port > 0;
-        # TODO: remove the true below which is only there for the transition period
-        prefixes       = (singleton 0) ++
-                         (optional (true || prometheus_enabled) cfg.prometheus_tunnel_port_prefix);
-        mkLimitation   = base_port: prefix: "permitlisten=\"${toString (add_port_prefix prefix base_port)}\"";
-        mkKeyConfig    = tunnel:
-          "${concatMapStringsSep "," (mkLimitation tunnel.remote_forward_port) prefixes} ${tunnel.public_key} tunnel@${tunnel.name}";
+        prefixes       = tunnel: get_prefixes tunnel.reverse_tunnels;
+        mkLimitation   = base_port: prefix:
+          ''permitlisten="${toString (add_port_prefix prefix base_port)}"'';
+        mkKeyConfig    = tunnel: concatStringsSep " " [
+          (concatMapStringsSep "," (mkLimitation tunnel.remote_forward_port)
+                                   (prefixes tunnel))
+          tunnel.public_key
+          "tunnel@${tunnel.name}"
+        ];
         mkKeyConfigs   = msf_lib.compose [ naturalSort
                                            (mapAttrsToList (_: mkKeyConfig))
                                            (filterAttrs (_: includeTunnel)) ];
       in {
-        extraGroups = mkIf cfg.relay.enable [ config.settings.users.ssh-group config.settings.users.rev-tunnel-group ];
+        extraGroups = mkIf cfg.relay.enable [ config.settings.users.ssh-group
+                                              config.settings.users.rev-tunnel-group ];
         openssh.authorizedKeys.keys = mkIf cfg.relay.enable (mkKeyConfigs cfg.tunnels);
       };
 
@@ -114,7 +206,8 @@ in {
         isSystemUser = true;
         shell        = pkgs.nologin;
         # The fwd-tunnel-group is required to be able to proxy through the relay
-        extraGroups  = [ config.settings.users.ssh-group config.settings.users.fwd-tunnel-group ];
+        extraGroups  = [ config.settings.users.ssh-group
+                         config.settings.users.fwd-tunnel-group ];
         openssh.authorizedKeys.keyFiles = cfg.relay.tunneller.keyFiles;
       };
     };
@@ -122,11 +215,12 @@ in {
     # This line is very important, it ensures that the remote hosts can
     # set up their reverse tunnels without any issues with host keys
     programs.ssh.knownHosts =
-      mapAttrs (_: conf: { hostNames = conf.addresses; publicKey = conf.public_key; })
+      mapAttrs (_: conf: { hostNames = conf.addresses;
+                           publicKey = conf.public_key; })
                cfg.relay_servers;
 
     systemd.services = let
-      make_tunnel_service = conf: {
+      make_tunnel_service = tunnel: relay: {
         enable = true;
         description = "AutoSSH reverse tunnel service to ensure resilient ssh access";
         wants = [ "network.target" ];
@@ -144,15 +238,21 @@ in {
           RestartSec = "10min";
         };
         script = let
-          tunnel_port = cfg.tunnels.${config.networking.hostName}.remote_forward_port;
-          prometheus_forward_line = let
-            prometheus_port = add_port_prefix cfg.prometheus_tunnel_port_prefix
-                                              tunnel_port;
-          in optionalString prometheus_enabled
-                            ''-R ${toString prometheus_port}:localhost:9100'';
+          mkRevTunLine = port: rev_tnl: concatStrings [
+            "-R "
+            (toString (add_port_prefix rev_tnl.prefix port))
+            ":localhost:"
+            (toString rev_tnl.forwarded_port)
+          ];
+          mkRevTunLines = port: msf_lib.compose [
+            (concatStringsSep " \\\n      ")
+            (mapAttrsToList (_: mkRevTunLine port))
+          ];
+          rev_tun_lines = mkRevTunLines tunnel.remote_forward_port
+                                        tunnel.reverse_tunnels;
         in ''
-          for host in ${concatStringsSep " " conf.addresses}; do
-            for port in ${concatMapStringsSep " " toString cfg.relay.ports}; do
+          for host in ${concatStringsSep " " relay.addresses}; do
+            for port in ${concatMapStringsSep " " toString relay.ports}; do
               echo "Attempting to connect to ''${host} on port ''${port}"
               ${pkgs.autossh}/bin/autossh \
                 -T -N \
@@ -166,8 +266,7 @@ in {
                 -o "IdentitiesOnly=yes" \
                 -o "Compression=yes" \
                 -o "ControlMaster=no" \
-                -R ${toString tunnel_port}:localhost:22 \
-                ${prometheus_forward_line} \
+                ${rev_tun_lines} \
                 -i ${sys_cfg.private_key} \
                 -p ''${port} \
                 -l tunnel \
@@ -176,10 +275,13 @@ in {
           done
         '';
       };
-      tunnel_services = optionalAttrs cfg.enable (
-        mapAttrs' (_: conf: nameValuePair "autossh-reverse-tunnel-${conf.name}"
-                                          (make_tunnel_service conf))
-                  cfg.relay_servers);
+      tunnel_services = optionalAttrs (cfg.enable &&
+                                       includeTunnel current_host_tunnel) (
+        mapAttrs' (_: relay: nameValuePair "autossh-reverse-tunnel-${relay.name}"
+                                           (make_tunnel_service current_host_tunnel
+                                                                relay))
+                  cfg.relay_servers
+      );
 
       monitoring_services = optionalAttrs cfg.relay.enable {
         port_monitor = {

--- a/modules/reverse-tunnel.nix
+++ b/modules/reverse-tunnel.nix
@@ -147,7 +147,8 @@ in {
       # Port 0 is ignored since it is a placeholder port.
       update_duplicates_set = tunnel: set: let
         port = toString (cfg.tunnels.${tunnel}.remote_forward_port);
-      in set // { ${port} = port != "0" && hasAttr port set; };
+        is_duplicate = set: port: port != "0" && hasAttr port set;
+      in set // { ${port} = is_duplicate set port; };
 
       # Use the update_duplicates_set function to calculate
       # a set marking duplicate ports, filter out the duplicates,

--- a/modules/sshd.nix
+++ b/modules/sshd.nix
@@ -64,7 +64,10 @@ with (import ../msf_lib.nix);
         passwordAuthentication = false;
         challengeResponseAuthentication = false;
         allowSFTP = true;
-        ports = mkIf reverse_tunnel.relay.enable reverse_tunnel.relay.ports;
+        ports = let
+          host_name   = config.networking.hostName;
+          relay_ports = reverse_tunnel.relay_servers.${host_name}.ports;
+        in mkIf reverse_tunnel.relay.enable relay_ports;
         kexAlgorithms = [ "curve25519-sha256@libssh.org"
                           "diffie-hellman-group18-sha512"
                           "diffie-hellman-group16-sha512" ];

--- a/msf_lib.nix
+++ b/msf_lib.nix
@@ -126,14 +126,21 @@ with lib;
       };
     };
 
+    # Generate a string consisting of a given number of spaces
+    # indentStr :: Int -> String -> String
+    indentStr = n: str: let
+      spacesN = compose [ concatStrings (genList (const " ")) ];
+    in (spacesN n) + str;
+
     reset_git = { branch
                 , git_options
                 , indent ? 0 }: let
       git = "${pkgs.git}/bin/git";
-      indentStr = compose [ concatStrings (genList (const " ")) ];
       mkOptionsStr = concatStringsSep " ";
       mkGitCommand = git_options: cmd: "${git} ${mkOptionsStr git_options} ${cmd}";
-    in concatMapStringsSep "\n${indentStr indent}" (mkGitCommand git_options) [
+      mkGitCommandIndented = indent: git_options:
+        compose [ (indentStr indent) (mkGitCommand git_options) ];
+    in concatMapStringsSep "\n" (mkGitCommandIndented indent git_options) [
       # The following line is only used to avoid the warning emitted by git.
       # We will reset the local repo anyway and remove all local changes.
       "config pull.rebase true"
@@ -240,7 +247,7 @@ with lib;
     inherit compose applyTwice filterEnabled ifPathExists
             host_name_type empty_str_type pub_key_type
             user_roles formats
-            reset_git clone_and_reset_git mkDeploymentService;
+            indentStr reset_git clone_and_reset_git mkDeploymentService;
   };
 }
 

--- a/msf_lib.nix
+++ b/msf_lib.nix
@@ -126,7 +126,7 @@ with lib;
       };
     };
 
-    # Generate a string consisting of a given number of spaces
+    # Prepend a string with a given number of spaces
     # indentStr :: Int -> String -> String
     indentStr = n: str: let
       spacesN = compose [ concatStrings (genList (const " ")) ];


### PR DESCRIPTION
* Remove all special cases for Prometheus, which were never used
* Make the prefixes generalised as concept and configurable,  no more special case for SSH, but we add SSH by default
* Add assertions to check for duplicate ports and prefixes
* Add an assertion to make sure that the relays are properly defined
* Make the module clearer overall