### PR TITLE
nixos: use modulesPath instead of <nixpkgs>

### DIFF
--- a/modules/aws.nix
+++ b/modules/aws.nix
@@ -1,10 +1,10 @@
-{ config, lib, ... }:
+{ modulesPath, config, lib, ... }:
 
 with lib;
 
 {
   imports = [
-    <nixpkgs/nixos/modules/virtualisation/amazon-image.nix>
+    "${modulesPath}/virtualisation/amazon-image.nix"
   ];
 
   ec2.hvm = true;

--- a/rescue_iso/iso.nix
+++ b/rescue_iso/iso.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, ... }:
+{ modulesPath, config, pkgs, lib, ... }:
 
 with lib;
 
@@ -7,8 +7,8 @@ let
 in {
 
   imports = [
-    <nixpkgs/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix>
-    <nixpkgs/nixos/modules/installer/cd-dvd/channel.nix>
+    "${modulesPath}/installer/cd-dvd/installation-cd-minimal.nix"
+    "${modulesPath}/installer/cd-dvd/channel.nix"
     ../modules
   ];
 


### PR DESCRIPTION
See #251. I had to create a PR from a local branch for the actions to work due to a limitation regarding secrets for PRs from forks.

Original comment:
> This is a general best practice to make NixOS more reproducible as it
> moves the configuration towards a more reproducible setup. The <nixpkgs>
> chevron depends on NIX_PATH, which might change from system to system.